### PR TITLE
Remove background color blocking preview view

### DIFF
--- a/TikTok/Base.lproj/Main.storyboard
+++ b/TikTok/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AXk-ZS-SmM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="AXk-ZS-SmM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -99,7 +99,7 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="Sno-dF-cQj" firstAttribute="centerY" secondItem="NHD-MK-cEZ" secondAttribute="centerY" id="2sy-DA-S0g"/>
                                             <constraint firstItem="8LB-TI-zCd" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="pEF-8l-hAf" secondAttribute="trailing" constant="8" symbolic="YES" id="33P-Bz-cvB"/>
@@ -189,8 +189,8 @@
     </scenes>
     <resources>
         <image name="camera_flip" width="280" height="241"/>
-        <image name="checkmark.circle.fill" catalog="system" width="64" height="60"/>
-        <image name="delete.left.fill" catalog="system" width="64" height="52"/>
-        <image name="xmark" catalog="system" width="64" height="56"/>
+        <image name="checkmark.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="delete.left.fill" catalog="system" width="128" height="104"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
     </resources>
 </document>


### PR DESCRIPTION
In the Recorder view controller there's a view inside the preview view with a gray background that prevents you from seeing the camera preview. This PR sets that color to clear so you can see the preview